### PR TITLE
[1.19.2] Added Mod Compats, More Tags, Fixes and Reworks

### DIFF
--- a/src/main/resources/data/c/tags/items/cinnamon.json
+++ b/src/main/resources/data/c/tags/items/cinnamon.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#c:crops/cinnamon"
+  ]
+}

--- a/src/main/resources/data/c/tags/items/crops.json
+++ b/src/main/resources/data/c/tags/items/crops.json
@@ -4,6 +4,7 @@
     "#c:crops/asparagus",
     "#c:crops/sweet_potato",
     "#c:crops/chili_pepper",
-    "#c:crops/peanut"
+    "#c:crops/peanut",
+    "#c:crops/cinnamon"
   ]
 }

--- a/src/main/resources/data/c/tags/items/crops/cinnamon.json
+++ b/src/main/resources/data/c/tags/items/crops/cinnamon.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "expandeddelight:raw_cinnamon"
+  ]
+}

--- a/src/main/resources/data/create/tags/items/upright_on_belt.json
+++ b/src/main/resources/data/create/tags/items/upright_on_belt.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:apple_juice",
+	"expandeddelight:sweet_berry_juice",
+	"expandeddelight:glow_berry_juice",
+	"expandeddelight:sweet_berry_jelly",
+	"expandeddelight:glow_berry_jelly",
+	"expandeddelight:glass_jar"
+  ]
+}

--- a/src/main/resources/data/expandeddelight/recipes/create/crushing/ground_cinnamon.json
+++ b/src/main/resources/data/expandeddelight/recipes/create/crushing/ground_cinnamon.json
@@ -2,7 +2,7 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "expandeddelight:raw_cinnamon"
+      "tag": "c:crops/cinnamon"
     }
   ],
   "results": [

--- a/src/main/resources/data/expandeddelight/recipes/create/cutting/cinnamon_log.json
+++ b/src/main/resources/data/expandeddelight/recipes/create/cutting/cinnamon_log.json
@@ -1,4 +1,10 @@
 {
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": ["create"]
+		}
+	],
 	"type":"create:cutting",
 	"ingredients":[
 		{

--- a/src/main/resources/data/expandeddelight/recipes/create/cutting/cinnamon_log.json
+++ b/src/main/resources/data/expandeddelight/recipes/create/cutting/cinnamon_log.json
@@ -1,0 +1,18 @@
+{
+	"type":"create:cutting",
+	"ingredients":[
+		{
+			"item":"expandeddelight:cinnamon_log"
+		}
+	],
+	"processingTime":50,
+	"results":[
+		{
+			"item":"stripped_oak_log"
+		},
+		{
+			"item":"expandeddelight:raw_cinnamon",
+			"count": 4
+		}
+	]
+}

--- a/src/main/resources/data/expandeddelight/recipes/create/milling/wild_asparagus.json
+++ b/src/main/resources/data/expandeddelight/recipes/create/milling/wild_asparagus.json
@@ -1,0 +1,24 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": ["create"]
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_asparagus"
+    }
+  ],
+  "results": [
+    {
+      "item": "expandeddelight:asparagus_seeds"
+    },
+    {
+      "count": 1,
+      "item": "brown_dye"
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/expandeddelight/recipes/create/milling/wild_chili_pepper.json
+++ b/src/main/resources/data/expandeddelight/recipes/create/milling/wild_chili_pepper.json
@@ -1,0 +1,24 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": ["create"]
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_chili_pepper"
+    }
+  ],
+  "results": [
+    {
+      "item": "expandeddelight:chili_pepper_seeds"
+    },
+    {
+      "count": 1,
+      "item": "white_dye"
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/expandeddelight/recipes/create/milling/wild_peanuts.json
+++ b/src/main/resources/data/expandeddelight/recipes/create/milling/wild_peanuts.json
@@ -1,0 +1,24 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": ["create"]
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_peanuts"
+    }
+  ],
+  "results": [
+    {
+      "item": "expandeddelight:peanut"
+    },
+    {
+      "count": 2,
+      "item": "yellow_dye"
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/expandeddelight/recipes/create/milling/wild_sweet_potatoes.json
+++ b/src/main/resources/data/expandeddelight/recipes/create/milling/wild_sweet_potatoes.json
@@ -1,0 +1,24 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": ["create"]
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_sweet_potatoes"
+    }
+  ],
+  "results": [
+    {
+      "item": "expandeddelight:sweet_potato"
+    },
+    {
+      "count": 2,
+      "item": "green_dye"
+    }
+  ],
+  "processingTime": 50
+}

--- a/src/main/resources/data/expandeddelight/recipes/farmersdelight/cooking/mac_and_cheese.json
+++ b/src/main/resources/data/expandeddelight/recipes/farmersdelight/cooking/mac_and_cheese.json
@@ -11,7 +11,7 @@
       "tag": "c:pasta"
     },
     {
-      "item": "expandeddelight:ground_salt"
+      "tag": "c:salt_dusts"
     }
   ],
   "result": {

--- a/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_asparagus.json
+++ b/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_asparagus.json
@@ -1,0 +1,25 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_asparagus"
+    }
+  ],
+  "result": [
+    {
+      "item": "expandeddelight:asparagus_seeds"
+    },
+	{
+      "item": "expandeddelight:asparagus",
+	  "chance": 0.2
+    },
+    {
+      "chance": 0.1,
+      "count": 1,
+      "item": "brown_dye"
+    }
+  ],
+  "tool": {
+    "tag": "c:tools/knives"
+  }
+}

--- a/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_chili_pepper.json
+++ b/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_chili_pepper.json
@@ -1,0 +1,25 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_chili_pepper"
+    }
+  ],
+  "result": [
+    {
+      "item": "expandeddelight:chili_pepper_seeds"
+    },
+	{
+      "item": "expandeddelight:chili_pepper",
+	  "chance": 0.2
+    },
+    {
+      "chance": 0.10,
+      "count": 1,
+      "item": "white_dye"
+    }
+  ],
+  "tool": {
+    "tag": "c:tools/knives"
+  }
+}

--- a/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_peanuts.json
+++ b/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_peanuts.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_peanuts"
+    }
+  ],
+  "result": [
+    {
+      "item": "expandeddelight:peanut"
+    },
+    {
+      "chance": 0.25,
+      "count": 2,
+      "item": "yellow_dye"
+    }
+  ],
+  "tool": {
+    "tag": "c:tools/knives"
+  }
+}

--- a/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_sweet_potatoes.json
+++ b/src/main/resources/data/expandeddelight/recipes/farmersdelight/cutting/wild_sweet_potatoes.json
@@ -1,0 +1,21 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "expandeddelight:wild_sweet_potatoes"
+    }
+  ],
+  "result": [
+    {
+      "item": "expandeddelight:sweet_potato"
+    },
+    {
+      "chance": 0.25,
+      "count": 2,
+      "item": "green_dye"
+    }
+  ],
+  "tool": {
+    "tag": "c:tools/knives"
+  }
+}

--- a/src/main/resources/data/expandeddelight/recipes/minecraft/crafting/sweet_potato_salad.json
+++ b/src/main/resources/data/expandeddelight/recipes/minecraft/crafting/sweet_potato_salad.json
@@ -11,7 +11,7 @@
       "tag": "c:crops/sweet_potato"
     },
     {
-      "item": "expandeddelight:raw_cinnamon"
+      "tag": "c:crops/cinnamon"
     },
     {
       "item": "minecraft:bowl"

--- a/src/main/resources/data/farmersdelight/recipes/melon_juice.json
+++ b/src/main/resources/data/farmersdelight/recipes/melon_juice.json
@@ -1,11 +1,11 @@
 {
   "fabric:load_conditions":[
-	{
-	  "condition": "fabric:not",
-	  "values": [
-		"expandeddelight"
-	  ]
-	}
+    {
+      "condition": "fabric:not",
+      "values": [
+        "expandeddelight"
+      ]
+    }
   ],
   "type": "minecraft:crafting_shapeless",
   "ingredients": [

--- a/src/main/resources/data/farmersdelight/recipes/melon_juice.json
+++ b/src/main/resources/data/farmersdelight/recipes/melon_juice.json
@@ -1,8 +1,34 @@
 {
+  "fabric:load_conditions":[
+	{
+	  "condition": "fabric:not",
+	  "values": [
+		"expandeddelight"
+	  ]
+	}
+  ],
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
+    {
+      "item": "minecraft:melon_slice"
+    },
+    {
+      "item": "minecraft:melon_slice"
+    },
+    {
+      "item": "minecraft:sugar"
+    },
+    {
+      "item": "minecraft:melon_slice"
+    },
+    {
+      "item": "minecraft:melon_slice"
+    },
+    {
+      "item": "minecraft:glass_bottle"
+    }
   ],
   "result": {
-    "item": ""
+    "item": "farmersdelight:melon_juice"
   }
 }

--- a/src/main/resources/data/farmersdelight/tags/items/comfort_foods.json
+++ b/src/main/resources/data/farmersdelight/tags/items/comfort_foods.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:peanut_honey_soup",
+	"expandeddelight:mac_and_cheese",
+	"expandeddelight:asparagus_soup_creamy",
+	"expandeddelight:asparagus_soup"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/crops.json
+++ b/src/main/resources/data/minecraft/tags/blocks/crops.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:asparagus_crop",
+	"expandeddelight:chili_pepper_crop",
+	"expandeddelight:peanut_crop",
+	"expandeddelight:sweet_potatoes_crop"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "expandeddelight:salt_ore",
-    "expandeddelight:deepslate_salt_ore"
+	"expandeddelight:mortar_and_pestle"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/saplings.json
+++ b/src/main/resources/data/minecraft/tags/blocks/saplings.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:cinnamon_sapling"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
+++ b/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:wild_asparagus",
+	"expandeddelight:wild_sweet_potatoes",
+	"expandeddelight:wild_chili_pepper",
+	"expandeddelight:wild_peanuts"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/oak_logs.json
+++ b/src/main/resources/data/minecraft/tags/items/oak_logs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:cinnamon_log"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/saplings.json
+++ b/src/main/resources/data/minecraft/tags/items/saplings.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:cinnamon_sapling"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/small_flowers.json
+++ b/src/main/resources/data/minecraft/tags/items/small_flowers.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:wild_asparagus",
+	"expandeddelight:wild_sweet_potatoes",
+	"expandeddelight:wild_chili_pepper",
+	"expandeddelight:wild_peanuts"
+  ]
+}

--- a/src/main/resources/data/supplementaries/tags/items/cookies.json
+++ b/src/main/resources/data/supplementaries/tags/items/cookies.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+	"expandeddelight:sugar_cookie",
+	"expandeddelight:chocolate_cookie",
+	"expandeddelight:snickerdoodle"
+  ]
+}


### PR DESCRIPTION
 ● Added expandeddelight:raw_cinnamon to **common** cinnamon tag and **common** crops tags
 
 ● Added **jar**, **jellies** and **juices** to **Create's upright_on_belt item tag**
 
 ● Added **Expanded Delight's cookies** to the **supplementaries:cookies item tag**
![2023-01-19_15 34 23](https://user-images.githubusercontent.com/114457180/213388357-9ea9a1d5-4567-4ad9-aee5-b3c60e5ef5af.png)

 ● Added **ED's Planted Crops** to **minecraft:crops block tag** 
 (to add support for enhanced celestials, right click harvest and other mods that uses this tag)

 ● Added **Mortar and Pestle** to **minecraft:mineable/pickaxe block tag** 
 (so it can be mined faster using pickaxes)

 ● Added **Cinnamon Sapling** to **minecraft:saplings item tag and block tag**

 ● Added **Wild Crops** to **minecraft:small_flowers item tag and block tag** 
 (because FD's wild crops are also in small_flowers tags)

 ● Added **Cinnamon Log** to **minecraft:oak_logs item tag**
 
 ● Reworked **Mac n' Cheese recipe** to **accept salt_dusts tag** as ingredient instead
 
 ● Added **cutting board recipes** for **ED's wild crops**
![2023-01-19_15 32 22](https://user-images.githubusercontent.com/114457180/213388786-3ae2b4e7-630a-4d35-968c-b8aa811033ec.png)

 ● Reworked **potato salad recipe** to **accept cinnamon tag** instead
 
 ● Reworked **Ground Cinnamon crushing recipe** to **accept cinnamon tag** instead

 ● Added **Create's Cutting compat** for **Cinnamon Log**
![2023-01-19_15 32 39](https://user-images.githubusercontent.com/114457180/213388950-6a8f83b4-779e-4206-b64f-cd82db3f4dc0.png)

 ● Added **Create's Milling recipes** for **ED's Wild Crops**
![2023-01-19_15 32 30](https://user-images.githubusercontent.com/114457180/213388966-6cae9910-f061-48e3-a815-fd3c0b921f02.png)

 ● Reworked **Melon Juice Recipe** to **not load using fabric:load_conditions**
 
  ● Added soups and mac n' cheese to comfort_foods