### PR TITLE
Propose adaptation of neoforge data load condition (1.21-1.21.3 only, not working in 1.21.4)

### DIFF
--- a/src/main/resources/data/farmersdelight/recipe/melon_juice.json
+++ b/src/main/resources/data/farmersdelight/recipe/melon_juice.json
@@ -1,7 +1,7 @@
 {
   "neoforge:conditions": [
     {
-      "type": "neoforge:never"
+      "type": "neoforge:false"
     }
   ]
 }

--- a/src/main/resources/data/farmersrespite/recipe/brewing/melon_juice_from_water.json
+++ b/src/main/resources/data/farmersrespite/recipe/brewing/melon_juice_from_water.json
@@ -1,7 +1,7 @@
 {
   "neoforge:conditions": [
     {
-      "type": "neoforge:never"
+      "type": "neoforge:false"
     }
   ]
 }


### PR DESCRIPTION
This should solve all possible cases of false alarms in pre 1.21.4 logs (but may cause them in 1.21.4)