### PR TITLE
Added missing cinnamon_log_horizontal.json

### DIFF
--- a/src/main/resources/assets/expandeddelight/models/block/cinnamon_log_horizontal.json
+++ b/src/main/resources/assets/expandeddelight/models/block/cinnamon_log_horizontal.json
@@ -1,0 +1,7 @@
+{
+  "parent": "minecraft:block/cube_column_horizontal",
+  "textures": {
+    "end": "expandeddelight:block/cinnamon_log_top",
+    "side": "expandeddelight:block/cinnamon_log"
+  }
+}


### PR DESCRIPTION
Fixed Cinnamon Log rendered pink/black when placed horizontally. https://github.com/ianm1647/expandeddelight/issues/104

I noticed that the issue has been fixed for Minecraft 1.21.1 versions. However, Minecraft 1.20.1 version hasn't been updated. It would be appreciated if the patch for 1.20.1 gets released in Modrinth.